### PR TITLE
Fix repository URL typo on docs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Docker4WordPress Documentation
 
-repo_url: https://github.com/wodby/docker4wordress
+repo_url: https://github.com/wodby/docker4wordpress
 site_description: 'Docker4WordPress – Docker-based WordPress environment for local development'
 theme: readthedocs
 


### PR DESCRIPTION
The docs site was missing a 'p' in WordPress, in the repo_url