### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,10 +3,10 @@ name: Run tests
 on:
   push:
     branches:
-    - master
+      - master
 
     tags:
-    - '*'
+      - "*"
 
   pull_request:
 
@@ -14,32 +14,32 @@ jobs:
   test:
     strategy:
       matrix:
-        php_ver: [ '8.3','8.2','8.1' ]
+        php_ver: ["8.3", "8.2", "8.1"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: test
-      env:
-        PHP_VER: ${{ matrix.php_ver }}
-      run: make test
+      - uses: actions/checkout@v4
+      - name: test
+        env:
+          PHP_VER: ${{ matrix.php_ver }}
+        run: make test
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     needs: test
     steps:
-    - uses: actions/checkout@v4
-    - name: prepare artifact
-      run: cp docker.mk Makefile && tar -czf docker4wordpress.tar.gz docker-compose.yml docker-compose.override.yml Makefile .env traefik.yml
-    - name: get tag name
-      id: vars
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-    - uses: xresloader/upload-to-github-release@v1
-      id: upload_artifact
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        file: docker4wordpress.tar.gz
-        overwrite: true
-        tags: true
-        draft: false
-        tag_name: ${{ steps.vars.outputs.tag }}
+      - uses: actions/checkout@v4
+      - name: prepare artifact
+        run: cp docker.mk Makefile && tar -czf docker4wordpress.tar.gz docker-compose.yml docker-compose.override.yml Makefile .env traefik.yml
+      - name: get tag name
+        id: vars
+        run: echo tag=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
+      - uses: xresloader/upload-to-github-release@v1
+        id: upload_artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: docker4wordpress.tar.gz
+          overwrite: true
+          tags: true
+          draft: false
+          tag_name: ${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


