### PR TITLE
Fix erroneous boolean in compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -18,7 +18,7 @@ services:
     environment:
       # By default xdebug extension also disabled.
       PHP_EXTENSIONS_DISABLE: xhprof,spx
-      PHP_MAIL_MIXED_LF_AND_CRLF: On
+      PHP_MAIL_MIXED_LF_AND_CRLF: "On"
       # Mailhog:
       MSMTP_HOST: mailhog
       MSMTP_PORT: 1025


### PR DESCRIPTION
The word `On` is a boolean in YAML, so we need to use `"On"` instead because Docker Compose's environment feature expects a string value.

```
$ make up
Starting up containers for my_wordpress_project...
docker-compose pull
ERROR: The Compose file './compose.yml' is invalid because:
services.php.environment.PHP_MAIL_MIXED_LF_AND_CRLF contains true, which is an invalid type, it should be a string, number, or a null
make: *** [docker.mk:16: up] Error 1
```